### PR TITLE
Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 ============
 
 ```
-   git clone git@github.com:SGSSGene/busy.git
+   git clone https://github.com/SGSSGene/busy.git
    cd busy
    ./bootstrap.sh
    sudo cp busy /usr/bin

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 mkdir -p packages
+rm -rf extRepositories/Serializer
 git clone https://github.com/SGSSGene/Serializer.git     extRepositories/Serializer
+rm -rf extRepositories/Process
 git clone https://github.com/SGSSGene/Process.git        extRepositories/Process
+rm -rf extRepositories/jsoncpp
 git clone https://github.com/SGSSGene/jsoncpp.git        extRepositories/jsoncpp
+rm -rf extRepositories/CommonOptions
 git clone https://github.com/SGSSGene/CommonOptions.git  extRepositories/CommonOptions
+rm -rf extRepositories/ThreadPool
 git clone https://github.com/SGSSGene/ThreadPool.git     extRepositories/ThreadPool
+rm -rf extRepositories/yaml-cpp
 git clone https://github.com/SGSSGene/yaml-cpp.git       extRepositories/yaml-cpp
 
 set -e

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 mkdir -p packages
-git clone git@github.com:SGSSGene/Serializer.git     extRepositories/Serializer
-git clone git@github.com:SGSSGene/Process.git        extRepositories/Process
-git clone git@github.com:SGSSGene/jsoncpp.git        extRepositories/jsoncpp
-git clone git@github.com:SGSSGene/CommonOptions.git  extRepositories/CommonOptions
-git clone git@github.com:SGSSGene/ThreadPool.git     extRepositories/ThreadPool
-git clone git@github.com:SGSSGene/yaml-cpp.git       extRepositories/yaml-cpp
+git clone https://github.com/SGSSGene/Serializer.git     extRepositories/Serializer
+git clone https://github.com/SGSSGene/Process.git        extRepositories/Process
+git clone https://github.com/SGSSGene/jsoncpp.git        extRepositories/jsoncpp
+git clone https://github.com/SGSSGene/CommonOptions.git  extRepositories/CommonOptions
+git clone https://github.com/SGSSGene/ThreadPool.git     extRepositories/ThreadPool
+git clone https://github.com/SGSSGene/yaml-cpp.git       extRepositories/yaml-cpp
 
 set -e
 

--- a/busy.yaml
+++ b/busy.yaml
@@ -1,8 +1,8 @@
 name: aBuild
 extRepositories:
-  - url: git@github.com:SGSSGene/Serializer.git
-  - url: git@github.com:SGSSGene/CommonOptions.git
-  - url: git@github.com:SGSSGene/ThreadPool.git
+  - url: https://github.com/SGSSGene/Serializer.git
+  - url: https://github.com/SGSSGene/CommonOptions.git
+  - url: https://github.com/SGSSGene/ThreadPool.git
 projects:
   - name: busy
     type: executable


### PR DESCRIPTION
- clonable without github accout and ssh key -> simplifies installing for users that just want to use busy as a tool
- if cloning while bootstrapping is incomplete, retrying the bootstrap procedure is more possible now 
